### PR TITLE
chore: use same name as openai documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project is a demonstration example using the [Elixir LangChain](https://git
 To start your LangChain Demo project:
 
   * Run `mix setup` to install and setup dependencies
+  * Setup your `export OPENAI_API_KEY=`, you can find more [here](https://platform.openai.com/docs/quickstart/step-2-setup-your-api-key)
   * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
 
 Now you can visit [`localhost:4400`](http://localhost:4400) from your browser.

--- a/config/config.exs
+++ b/config/config.exs
@@ -51,7 +51,7 @@ config :tailwind,
     cd: Path.expand("../assets", __DIR__)
   ]
 
-config :langchain, :openai_key, fn -> System.fetch_env!("OPENAI_KEY") end
+config :langchain, :openai_key, fn -> System.fetch_env!("OPENAI_API_KEY") end
 
 # Configures Elixir's Logger
 config :logger, :console,


### PR DESCRIPTION
let's keep with the same name as openai docs?

https://platform.openai.com/docs/quickstart/step-2-setup-your-api-key

instead of `OPENAI_KEY` 
use it as `OPENAI_API_KEY`

what do you think about?